### PR TITLE
fixed @userForName deprecated method

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -13,10 +13,10 @@ class WebAdapter extends Adapter
     message.replace(/\n/g, "<br>")
 
   createUser: (username, room) ->
-    user = @userForName username
+    user = @robot.brain.userForName username
     unless user?
       id = new Date().getTime().toString()
-      user = @userForId id
+      user = @robot.brain.userForId id
       user.name = username
 
     user.room = room


### PR DESCRIPTION
Updates the usreForName and userForId methods to remove the warning due to the next version of hubot.
[WARNING @userForName() is going to be deprecated in 3.0.0 use @robot.brain.userForName()]
